### PR TITLE
allow DDEV to auto-name

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,4 +1,3 @@
-name: d10-base-demo
 type: drupal10
 docroot: web
 php_version: "8.1"


### PR DESCRIPTION
## Problem
When cloning this project, users should rename it to prevent clashes.

## Solution
When `.ddev/config.yaml` is missing the `name` key, DDEV will automatically set the project name to the project folder.

One 


<a href="https://gitpod.io/#https://github.com/tyler36/d10-base-demo/pull/1"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

