### PR TITLE
set generic SIMPLETEST_BASE_URL

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,7 +4,7 @@
   <php>
     <ini name="error_reporting" value="32767"/>
     <ini name="memory_limit" value="-1"/>
-    <env name="SIMPLETEST_BASE_URL" value="https://d10-base-demo.ddev.site"/>
+    <env name="SIMPLETEST_BASE_URL" value="https://web"/>
     <!-- <env name="SIMPLETEST_DB" value="sqlite://localhost/sites/default/files/.ht.sqlite"/> -->
     <env name="SIMPLETEST_DB" value="mysql://db:db@db/db"/>
     <env name="BROWSERTEST_OUTPUT_DIRECTORY" value="web/sites/simpletest/browser_output"/>


### PR DESCRIPTION
## Problem

When cloning this repo, the "SIMPLETEST_BASE_URL" should be manually updated before functional tests will run correctly.

## Solution

Because functional tests run better from inside the DDEV web container, this PR sets the BASE_URL to the generic URL used within the web container.

<a href="https://gitpod.io/#https://github.com/tyler36/d10-base-demo/pull/2"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

