### PR TITLE
Improve performance of functional tests by caching Drupal installations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     ],
     "require": {
         "composer/installers": "^2.0",
+        "cweagans/composer-patches": "^1.7",
         "drupal/admin_toolbar": "^3.3",
         "drupal/core-composer-scaffold": "^10.0",
         "drupal/core-project-message": "^10.0",

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,12 @@
         "sort-packages": true
     },
     "extra": {
+        "enable-patching": true,
+        "patches": {
+            "drupal/core": {
+                "improve-phpunit-performance": "./patches/drupal-core_2900208-48.patch"
+            }
+        },
         "drupal-scaffold": {
             "locations": {
                 "web-root": "web/"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "aab0772f95e1120a7b6375bb4afbdbd9",
+    "content-hash": "3ec608b1394bcef17e31ec4560a39794",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -287,6 +287,54 @@
                 }
             ],
             "time": "2022-04-01T19:23:25+00:00"
+        },
+        {
+            "name": "cweagans/composer-patches",
+            "version": "1.7.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cweagans/composer-patches.git",
+                "reference": "e190d4466fe2b103a55467dfa83fc2fecfcaf2db"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cweagans/composer-patches/zipball/e190d4466fe2b103a55467dfa83fc2fecfcaf2db",
+                "reference": "e190d4466fe2b103a55467dfa83fc2fecfcaf2db",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "composer/composer": "~1.0 || ~2.0",
+                "phpunit/phpunit": "~4.6"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "cweagans\\Composer\\Patches"
+            },
+            "autoload": {
+                "psr-4": {
+                    "cweagans\\Composer\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Cameron Eagans",
+                    "email": "me@cweagans.net"
+                }
+            ],
+            "description": "Provides a way to patch Composer packages.",
+            "support": {
+                "issues": "https://github.com/cweagans/composer-patches/issues",
+                "source": "https://github.com/cweagans/composer-patches/tree/1.7.3"
+            },
+            "time": "2022-12-20T22:53:13+00:00"
         },
         {
             "name": "doctrine/annotations",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3ec608b1394bcef17e31ec4560a39794",
+    "content-hash": "57f39d7eb95763d28cee8915f33dc3f9",
     "packages": [
         {
             "name": "asm89/stack-cors",

--- a/patches/drupal-core_2900208-48.patch
+++ b/patches/drupal-core_2900208-48.patch
@@ -1,0 +1,185 @@
+diff --git a/core/lib/Drupal/Core/Test/FunctionalTestSetupTrait.php b/core/lib/Drupal/Core/Test/FunctionalTestSetupTrait.php
+index 32cb051dd6..cde942272c 100644
+--- a/core/lib/Drupal/Core/Test/FunctionalTestSetupTrait.php
++++ b/core/lib/Drupal/Core/Test/FunctionalTestSetupTrait.php
+@@ -711,4 +711,117 @@ protected function getDatabaseTypes() {
+     return $database_types;
+   }
+
++  /**
++   * Installs Drupal using SQL dump.
++   */
++  protected function installDrupalFromDump() {
++
++    $this->restoreDatabase();
++
++    $this->initUserSession();
++    $this->prepareSettings();
++
++    $connection_info = Database::getConnectionInfo('default');
++
++    $databases['default']['default'] = (object) [
++      'value' => $connection_info['default'],
++      'required' => TRUE,
++    ];
++
++    $settings['databases'] = $databases;
++    $settings['settings']['hash_salt'] = (object) [
++      'value' => $this->databasePrefix,
++      'required' => TRUE,
++    ];
++
++    $settings['settings']['hash_salt'] = (object) [
++      'value' => $this->databasePrefix,
++      'required' => TRUE,
++    ];
++
++    $settings['settings']['file_public_path'] = (object) [
++      'value' => $this->publicFilesDirectory,
++      'required' => TRUE,
++    ];
++    $settings['settings']['file_private_path'] = (object) [
++      'value' => $this->privateFilesDirectory,
++      'required' => TRUE,
++    ];
++    $settings['settings']['file_temp_path'] = (object) [
++      'value' => $this->tempFilesDirectory,
++      'required' => TRUE,
++    ];
++
++    $this->writeSettings($settings);
++
++    // During tests, cacheable responses should get the debugging cacheability
++    // headers by default.
++    $this->setContainerParameter('http.response.debug_cacheability_headers', TRUE);
++
++    $autoloader = require './autoload.php';
++    $this->kernel = new DrupalKernel('prod', $autoloader);
++    $request = Request::createFromGlobals();
++    DrupalKernel::bootEnvironment();
++    $site_path = DrupalKernel::findSitePath($request);
++    $this->kernel->setSitePath($site_path);
++    Settings::initialize($this->kernel->getAppRoot(), $this->kernel->getSitePath(), $autoloader);
++    $this->kernel->boot()->preHandle($request);
++    $this->container = $this->kernel->getContainer();
++
++    // The value comes with the dump from previous installation.
++    \Drupal::configFactory()->getEditable('system.file')
++      ->set('path.temporary', $this->tempFilesDirectory)
++      ->save();
++    \Drupal::service('file_system')->prepareDirectory($this->tempFilesDirectory, FileSystemInterface::MODIFY_PERMISSIONS | FileSystemInterface::CREATE_DIRECTORY);
++
++    // Manually create the private directory.
++    \Drupal::service('file_system')->prepareDirectory($this->privateFilesDirectory, FileSystemInterface::CREATE_DIRECTORY);
++  }
++
++  /**
++   * Dumps database structure and contents of test site.
++   */
++  protected function dumpDatabase() {
++    $connection_info = Database::getConnectionInfo('default');
++
++    $user = $connection_info['default']['username'];
++    $pass = $connection_info['default']['password'];
++    $db = $connection_info['default']['database'];
++    $host = $connection_info['default']['host'];
++
++    switch ($connection_info['default']['driver']) {
++      case 'mysql':
++        $tables = \Drupal::database()
++          ->query("SHOW TABLES LIKE '$this->databasePrefix%'")
++          ->fetchCol();
++        $tables_param = implode(' ', $tables);
++        exec("mysqldump -u$user -p$pass -h $host $db $tables_param | sed 's/$this->databasePrefix/default_db_prefix_/' > {$this->dumpFile}");
++        break;
++
++      default:
++        throw new \LogicException('This database driver is not supported yet.');
++    }
++  }
++
++  /**
++   * Restores database structure and contents of test site.
++   */
++  protected function restoreDatabase() {
++    $connection_info = Database::getConnectionInfo('default');
++
++    $user = $connection_info['default']['username'];
++    $pass = $connection_info['default']['password'];
++    $db = $connection_info['default']['database'];
++    $host = $connection_info['default']['host'];
++
++    switch ($connection_info['default']['driver']) {
++      case 'mysql':
++        exec("sed 's/default_db_prefix_/$this->databasePrefix/' $this->dumpFile | mysql -u$user -p$pass -h $host $db");
++        break;
++
++      default:
++        throw new \LogicException('This database driver is not supported yet.');
++    }
++  }
++
+ }
+diff --git a/core/tests/Drupal/Tests/BrowserTestBase.php b/core/tests/Drupal/Tests/BrowserTestBase.php
+index 4c452d0051..13df0ba1f2 100644
+--- a/core/tests/Drupal/Tests/BrowserTestBase.php
++++ b/core/tests/Drupal/Tests/BrowserTestBase.php
+@@ -75,6 +75,13 @@ abstract class BrowserTestBase extends TestCase {
+   use ExpectDeprecationTrait;
+   use ExtensionListTestTrait;
+
++  /**
++   * Path to SQL dump file.
++   *
++   * @var string
++   */
++  protected $dumpFile;
++
+   /**
+    * Time limit in seconds for the test.
+    *
+@@ -535,6 +542,44 @@ protected function getOptions($select, Element $container = NULL) {
+    * Installs Drupal into the Simpletest site.
+    */
+   public function installDrupal() {
++    if (getenv('BROWSERTEST_CACHE_DB')) {
++      $this->initDumpFile();
++      if (file_exists($this->dumpFile)) {
++        $this->installDrupalFromDump();
++      }
++      else {
++        $this->installDrupalFromProfile();
++        $this->dumpDatabase();
++      }
++    }
++    else {
++      $this->installDrupalFromProfile();
++    }
++  }
++
++  /**
++   * Determines a proper file name for SQL dump.
++   */
++  protected function initDumpFile() {
++    $class = get_class($this);
++    $modules = [];
++    while ($class) {
++      if (property_exists($class, 'modules')) {
++        $modules = array_merge($modules, $class::$modules);
++      }
++      $class = get_parent_class($class);
++    }
++    sort($modules);
++    array_unique($modules);
++    $cache_dir = getenv('BROWSERTEST_CACHE_DIR') ?: sys_get_temp_dir() . '/test_dumps/' . \Drupal::VERSION;
++    is_dir($cache_dir) || mkdir($cache_dir, 0777, TRUE);
++    $this->dumpFile = $cache_dir . '/_' . md5(implode('-', $modules)) . '.sql';
++  }
++
++  /**
++   * Installs Drupal using installation profile.
++   */
++  protected function installDrupalFromProfile() {
+     $this->initUserSession();
+     $this->prepareSettings();
+     $this->doInstall();


### PR DESCRIPTION
See https://www.drupal.org/project/drupal/issues/2900208

This PR applies patch #48 which decresed test time by 40% in test projects.




<a href="https://gitpod.io/#https://github.com/tyler36/d10-base-demo/pull/5"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

