### PR TITLE
PHPCS should not check CSS

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -7,7 +7,7 @@
   <arg name="colors"/>
 
   <!-- Additional file types -->
-  <arg name="extensions" value="css,info,inc,install,module,php,profile,md,test,theme,txt,yml"/>
+  <arg name="extensions" value="info,inc,install,module,php,profile,md,test,theme,txt,yml"/>
 
   <!--Exclude third party code.-->
   <exclude-pattern>*/vendor/*</exclude-pattern>


### PR DESCRIPTION
PHPCS reports false positives when using some modern frameworks (TailwindCSS).

Offficial, support was stopped in `v3` and will be removed in `v4`.

@see https://github.com/squizlabs/PHP_CodeSniffer/issues/3364

<a href="https://gitpod.io/#https://github.com/tyler36/d10-base-demo/pull/7"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

