### PR TITLE
Fix "BROWSERTEST_OUTPUT_DIRECTORY"

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,7 +7,7 @@
     <env name="SIMPLETEST_BASE_URL" value="https://web"/>
     <!-- <env name="SIMPLETEST_DB" value="sqlite://localhost/sites/default/files/.ht.sqlite"/> -->
     <env name="SIMPLETEST_DB" value="mysql://db:db@db/db"/>
-    <env name="BROWSERTEST_OUTPUT_DIRECTORY" value="web/sites/simpletest/browser_output"/>
+    <env name="BROWSERTEST_OUTPUT_DIRECTORY" value="sites/simpletest/browser_output"/>
     <env name="BROWSERTEST_OUTPUT_BASE_URL" value=""/>
     <env name="MINK_DRIVER_CLASS" value=''/>
     <env name="MINK_DRIVER_ARGS" value=''/>


### PR DESCRIPTION
This PR resolves an issue where Drupal changed the default directory.

Drupal `>=10.2` sets `BROWSERTEST_OUTPUT_DIRECTORY` relative to `WEBROOT`.

- ❌ `/var/www/html` (DOCROOT)
- ✅ `/var/www/html/web` (WEBROOT)

<a href="https://gitpod.io/#https://github.com/tyler36/d10-base-demo/pull/46"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

